### PR TITLE
Fix code scanning alert no. 1: Database query built from user-controlled sources

### DIFF
--- a/src/pokemon/pokemon.service.ts
+++ b/src/pokemon/pokemon.service.ts
@@ -69,7 +69,7 @@ export class PokemonService {
     if (updatePokemonDto.name)
       updatePokemonDto.name = updatePokemonDto.name.toLowerCase();
     try {
-      await pokemon.updateOne(updatePokemonDto);
+      await pokemon.updateOne({ $set: updatePokemonDto });
 
       return { ...pokemon.toJSON(), ...updatePokemonDto };
     } catch (error) {


### PR DESCRIPTION
Fixes [https://github.com/Juan-Camilo-Sanchez-Echeverri/pokedex/security/code-scanning/1](https://github.com/Juan-Camilo-Sanchez-Echeverri/pokedex/security/code-scanning/1)

To fix the problem, we need to ensure that the user-provided data in `updatePokemonDto` is sanitized before being used in the database query. This can be achieved by using MongoDB's `$set` operator to explicitly set the fields to be updated, ensuring that the input is treated as literal values. Additionally, we should validate the `updatePokemonDto` object to ensure it contains only the expected fields.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
